### PR TITLE
Add governance ownership and security contribution policies

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# ProvenClaw ownership map
+# Replace individual owners with org teams as they are created.
+
+# Default ownership
+* @markthom-as
+
+# Security-critical surfaces
+/crates/provenclaw-core/ @markthom-as
+/crates/provenclaw-host/ @markthom-as
+/crates/provenclaw-policy/ @markthom-as
+/crates/provenclaw-audit/ @markthom-as
+/.github/workflows/ @markthom-as
+/deny.toml @markthom-as
+/Cargo.toml @markthom-as
+/Cargo.lock @markthom-as

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing
+
+## Development Setup
+
+1. Install Rust with `rustup`.
+2. Use the repository toolchain from `rust-toolchain.toml`.
+3. Clone the repository and initialize local layout with `cargo run -p provenclaw-cli -- init`.
+
+## Required Checks Before PR
+
+Run all checks locally:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+cargo deny check advisories bans sources
+cargo audit
+./scripts/spec_parity.sh
+```
+
+## Pull Request Requirements
+
+1. Use a feature branch (prefix `codex/` is preferred for Codex-generated work).
+2. Keep changes scoped and include tests for behavior changes.
+3. Document security-impacting changes in `README.md` or `/docs` as needed.
+4. Ensure CI is green before merge.
+
+## Security Requirements
+
+1. Do not add fallback execution paths that bypass provenance checks.
+2. Keep capability enforcement deny-by-default.
+3. Treat host ABI and policy schema changes as security-sensitive.
+4. Never commit raw secrets or secret material.
+
+## Release and Signing Expectations
+
+1. Release tags must be annotated and signed.
+2. Release notes must include:
+   - toolchain version,
+   - gate results,
+   - security-relevant dependency changes.
+3. Runtime and policy artifacts must remain digest-addressed and verifiable.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Policy
+
+## Supported Versions
+
+This repository is currently in active Phase 0.5 development. The `main` branch is the supported branch for security fixes.
+
+## Reporting a Vulnerability
+
+1. Do not open a public issue for suspected vulnerabilities.
+2. Use GitHub's private vulnerability reporting for this repository:
+   [Security Advisories](https://github.com/opertus-systems/provenclaw/security/advisories).
+3. Include clear reproduction steps, impact, affected paths, and any proof-of-concept artifacts.
+
+## Response Targets
+
+1. Initial acknowledgement: within 2 business days.
+2. Triage and severity classification: within 5 business days.
+3. Remediation or mitigation plan: as soon as triage is complete.
+
+## Disclosure Policy
+
+1. We follow coordinated disclosure.
+2. Public disclosure happens only after a fix or acceptable mitigation is available.
+3. Security regressions can block releases.
+
+## Scope Notes
+
+1. Provenance and policy bypasses are considered high severity.
+2. Receipt or audit-chain tampering is considered high severity.
+3. Secret material exposure outside approved boundaries is considered high severity.


### PR DESCRIPTION
## Summary
- add CODEOWNERS for default and security-critical paths
- add SECURITY.md with private vulnerability reporting + response targets
- add CONTRIBUTING.md with required gates and release/signing expectations

## Why
- establish ownership and security governance baseline before broader contributor onboarding