### PR TITLE
Phase 1: add control-plane skeleton and trust boundaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1213,6 +1213,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "provenclaw-control-plane"
+version = "0.1.0"
+dependencies = [
+ "provenclaw-core",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "provenclaw-core"
 version = "0.1.0"
 dependencies = [
@@ -1236,6 +1245,7 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "provenclaw-audit",
+ "provenclaw-control-plane",
  "provenclaw-core",
  "provenclaw-policy",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "crates/provenclaw-host",
   "crates/provenclaw-policy",
   "crates/provenclaw-audit",
+  "crates/provenclaw-control-plane",
   "crates/provenclaw-cli",
   "crates/provenclaw-api",
   "crates/provenclaw-tui",

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Phase 0.5 adds a TUI-first operator experience (`provenclaw`) plus script-friend
 - `/Users/jove/code/provenclaw/crates/provenclaw-host`: runtime, provenance, signing, trust, enforcement.
 - `/Users/jove/code/provenclaw/crates/provenclaw-policy`: policy parsing/evaluation/signature checks.
 - `/Users/jove/code/provenclaw/crates/provenclaw-audit`: receipt persistence and audit-chain verification.
+- `/Users/jove/code/provenclaw/crates/provenclaw-control-plane`: control-plane contracts, transport/auth hooks, authorization boundary.
 - `/Users/jove/code/provenclaw/crates/provenclaw-cli`: command router and automation interface.
 - `/Users/jove/code/provenclaw/crates/provenclaw-tui`: full-screen terminal UX (ratatui + crossterm).
 - `/Users/jove/code/provenclaw/crates/provenclaw-api`: optional local API schemas.
@@ -50,6 +51,7 @@ cargo run -p provenclaw-cli -- diagnostics security-report
 ## Docs
 
 - `/Users/jove/code/provenclaw/docs/ARCHITECTURE.md`
+- `/Users/jove/code/provenclaw/docs/CONTROL_PLANE.md`
 - `/Users/jove/code/provenclaw/docs/THREAT_MODEL.md`
 - `/Users/jove/code/provenclaw/docs/OPERATIONS.md`
 - `/Users/jove/code/provenclaw/docs/ENTERPRISE_README.md`

--- a/crates/provenclaw-control-plane/Cargo.toml
+++ b/crates/provenclaw-control-plane/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "provenclaw-control-plane"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+provenclaw-core = { path = "../provenclaw-core" }
+serde.workspace = true
+thiserror.workspace = true

--- a/crates/provenclaw-control-plane/src/lib.rs
+++ b/crates/provenclaw-control-plane/src/lib.rs
@@ -1,0 +1,399 @@
+use provenclaw_core::EnforcementMode;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ControlPlaneError {
+    #[error("invalid request: {0}")]
+    InvalidRequest(String),
+    #[error("unsupported transport endpoint: {0}")]
+    UnsupportedTransport(String),
+    #[error("authorization denied: {0}")]
+    Unauthorized(String),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ControlPlaneMode {
+    LocalOnly,
+    Hybrid,
+    RemoteOnly,
+}
+
+impl Default for ControlPlaneMode {
+    fn default() -> Self {
+        Self::LocalOnly
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TransportKind {
+    InProcess,
+    UnixSocket,
+    LoopbackHttp,
+    MtlsHttps,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthnScheme {
+    LocalSharedToken,
+    OidcBearer,
+    MutualTls,
+    WorkloadIdentity,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum HookMode {
+    Disabled,
+    Local,
+    External,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AuthnHook {
+    pub mode: HookMode,
+    #[serde(default)]
+    pub accepted_schemes: Vec<AuthnScheme>,
+    #[serde(default)]
+    pub audience: Option<String>,
+}
+
+impl Default for AuthnHook {
+    fn default() -> Self {
+        Self {
+            mode: HookMode::Local,
+            accepted_schemes: vec![AuthnScheme::LocalSharedToken],
+            audience: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AuthzHook {
+    pub mode: HookMode,
+    pub policy_source: String,
+}
+
+impl Default for AuthzHook {
+    fn default() -> Self {
+        Self {
+            mode: HookMode::Local,
+            policy_source: "embedded-rbac".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ControlPlaneEndpoint {
+    pub transport: TransportKind,
+    pub address: String,
+    #[serde(default)]
+    pub audience: Option<String>,
+}
+
+impl ControlPlaneEndpoint {
+    pub fn validate(&self) -> Result<(), ControlPlaneError> {
+        match self.transport {
+            TransportKind::InProcess => {
+                if !self.address.eq_ignore_ascii_case("in-process") {
+                    return Err(ControlPlaneError::UnsupportedTransport(
+                        "in-process transport requires address=in-process".to_string(),
+                    ));
+                }
+            }
+            TransportKind::LoopbackHttp => {
+                if !(self.address.starts_with("127.0.0.1:")
+                    || self.address.starts_with("localhost:"))
+                {
+                    return Err(ControlPlaneError::UnsupportedTransport(
+                        "loopback HTTP transport requires localhost/127.0.0.1".to_string(),
+                    ));
+                }
+            }
+            TransportKind::UnixSocket => {
+                if !self.address.starts_with('/') {
+                    return Err(ControlPlaneError::UnsupportedTransport(
+                        "unix socket transport requires absolute path".to_string(),
+                    ));
+                }
+            }
+            TransportKind::MtlsHttps => {
+                if !self.address.starts_with("https://") {
+                    return Err(ControlPlaneError::UnsupportedTransport(
+                        "mTLS HTTPS transport requires https:// endpoint".to_string(),
+                    ));
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ControlPlaneProfile {
+    pub mode: ControlPlaneMode,
+    pub endpoint: ControlPlaneEndpoint,
+    pub authn: AuthnHook,
+    pub authz: AuthzHook,
+    pub host_enforcement_mode: EnforcementMode,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ControlPlaneHealth {
+    Ready,
+    Degraded,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SubjectContext {
+    pub subject_id: String,
+    #[serde(default)]
+    pub roles: BTreeSet<String>,
+    pub authn_scheme: AuthnScheme,
+    #[serde(default)]
+    pub scopes: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthorizationAction {
+    RunTool,
+    ReadReceipts,
+    VerifyReceipts,
+    TailAudit,
+    ExportDiagnostics,
+    ManagePolicy,
+    ManageTrust,
+    SetEnforcementMode,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResourceContext {
+    pub resource_kind: String,
+    pub resource_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AuthorizationRequest {
+    pub subject: SubjectContext,
+    pub action: AuthorizationAction,
+    #[serde(default)]
+    pub resource: Option<ResourceContext>,
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthorizationDecision {
+    Allow,
+    Deny,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AuthorizationResponse {
+    pub decision: AuthorizationDecision,
+    pub reason_code: String,
+    pub remediation_hint: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ControlPlaneRequest {
+    Health,
+    Profile,
+    Authorize(AuthorizationRequest),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ControlPlaneResponse {
+    Health(ControlPlaneHealth),
+    Profile(ControlPlaneProfile),
+    Authorize(AuthorizationResponse),
+}
+
+pub trait ControlPlane {
+    fn profile(&self) -> ControlPlaneProfile;
+
+    fn health(&self) -> ControlPlaneHealth;
+
+    fn authorize(
+        &self,
+        request: &AuthorizationRequest,
+    ) -> Result<AuthorizationResponse, ControlPlaneError>;
+
+    fn execute(
+        &self,
+        request: ControlPlaneRequest,
+    ) -> Result<ControlPlaneResponse, ControlPlaneError> {
+        match request {
+            ControlPlaneRequest::Health => Ok(ControlPlaneResponse::Health(self.health())),
+            ControlPlaneRequest::Profile => Ok(ControlPlaneResponse::Profile(self.profile())),
+            ControlPlaneRequest::Authorize(request) => {
+                Ok(ControlPlaneResponse::Authorize(self.authorize(&request)?))
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LocalControlPlane {
+    profile: ControlPlaneProfile,
+}
+
+impl LocalControlPlane {
+    pub fn for_local_host(enforcement_mode: EnforcementMode) -> Self {
+        Self {
+            profile: ControlPlaneProfile {
+                mode: ControlPlaneMode::LocalOnly,
+                endpoint: ControlPlaneEndpoint {
+                    transport: TransportKind::InProcess,
+                    address: "in-process".to_string(),
+                    audience: None,
+                },
+                authn: AuthnHook::default(),
+                authz: AuthzHook::default(),
+                host_enforcement_mode: enforcement_mode,
+            },
+        }
+    }
+
+    pub fn with_profile(profile: ControlPlaneProfile) -> Result<Self, ControlPlaneError> {
+        profile.endpoint.validate()?;
+        Ok(Self { profile })
+    }
+}
+
+impl ControlPlane for LocalControlPlane {
+    fn profile(&self) -> ControlPlaneProfile {
+        self.profile.clone()
+    }
+
+    fn health(&self) -> ControlPlaneHealth {
+        ControlPlaneHealth::Ready
+    }
+
+    fn authorize(
+        &self,
+        request: &AuthorizationRequest,
+    ) -> Result<AuthorizationResponse, ControlPlaneError> {
+        if request.subject.subject_id.trim().is_empty() {
+            return Err(ControlPlaneError::InvalidRequest(
+                "subject_id is required".to_string(),
+            ));
+        }
+
+        let required_roles = required_roles(&request.action);
+        let has_required_role = required_roles
+            .iter()
+            .any(|role| request.subject.roles.contains(*role));
+
+        if !has_required_role {
+            return Ok(AuthorizationResponse {
+                decision: AuthorizationDecision::Deny,
+                reason_code: "authz.role-mismatch".to_string(),
+                remediation_hint: format!(
+                    "grant one of required roles: {}",
+                    required_roles.join(",")
+                ),
+            });
+        }
+
+        Ok(AuthorizationResponse {
+            decision: AuthorizationDecision::Allow,
+            reason_code: "authz.role-match".to_string(),
+            remediation_hint: "none".to_string(),
+        })
+    }
+}
+
+fn required_roles(action: &AuthorizationAction) -> &'static [&'static str] {
+    match action {
+        AuthorizationAction::RunTool
+        | AuthorizationAction::ReadReceipts
+        | AuthorizationAction::VerifyReceipts
+        | AuthorizationAction::TailAudit
+        | AuthorizationAction::ExportDiagnostics => &["operator", "auditor", "security-admin"],
+        AuthorizationAction::ManagePolicy
+        | AuthorizationAction::ManageTrust
+        | AuthorizationAction::SetEnforcementMode => &["security-admin"],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn subject_with_roles(roles: &[&str]) -> SubjectContext {
+        SubjectContext {
+            subject_id: "alice".to_string(),
+            roles: roles.iter().map(|role| role.to_string()).collect(),
+            authn_scheme: AuthnScheme::LocalSharedToken,
+            scopes: BTreeSet::new(),
+        }
+    }
+
+    #[test]
+    fn local_profile_defaults_to_in_process_transport() {
+        let plane = LocalControlPlane::for_local_host(EnforcementMode::Warn);
+        let profile = plane.profile();
+        assert_eq!(profile.mode, ControlPlaneMode::LocalOnly);
+        assert_eq!(profile.endpoint.transport, TransportKind::InProcess);
+        assert_eq!(profile.endpoint.address, "in-process");
+    }
+
+    #[test]
+    fn authorize_denies_when_subject_lacks_role() {
+        let plane = LocalControlPlane::for_local_host(EnforcementMode::Warn);
+        let request = AuthorizationRequest {
+            subject: subject_with_roles(&["operator"]),
+            action: AuthorizationAction::ManageTrust,
+            resource: None,
+            reason: None,
+        };
+
+        let response = plane.authorize(&request).unwrap();
+        assert_eq!(response.decision, AuthorizationDecision::Deny);
+        assert_eq!(response.reason_code, "authz.role-mismatch");
+    }
+
+    #[test]
+    fn authorize_allows_when_subject_has_required_role() {
+        let plane = LocalControlPlane::for_local_host(EnforcementMode::Warn);
+        let request = AuthorizationRequest {
+            subject: subject_with_roles(&["security-admin"]),
+            action: AuthorizationAction::SetEnforcementMode,
+            resource: None,
+            reason: None,
+        };
+
+        let response = plane.authorize(&request).unwrap();
+        assert_eq!(response.decision, AuthorizationDecision::Allow);
+    }
+
+    #[test]
+    fn endpoint_validation_rejects_non_loopback_http() {
+        let profile = ControlPlaneProfile {
+            mode: ControlPlaneMode::RemoteOnly,
+            endpoint: ControlPlaneEndpoint {
+                transport: TransportKind::LoopbackHttp,
+                address: "10.0.0.4:7447".to_string(),
+                audience: Some("provenclaw-host".to_string()),
+            },
+            authn: AuthnHook::default(),
+            authz: AuthzHook::default(),
+            host_enforcement_mode: EnforcementMode::Warn,
+        };
+
+        let err = LocalControlPlane::with_profile(profile).unwrap_err();
+        assert!(err.to_string().contains("loopback HTTP"));
+    }
+}

--- a/crates/provenclaw-host/Cargo.toml
+++ b/crates/provenclaw-host/Cargo.toml
@@ -19,6 +19,7 @@ dirs.workspace = true
 ed25519-dalek.workspace = true
 hex.workspace = true
 provenclaw-audit = { path = "../provenclaw-audit" }
+provenclaw-control-plane = { path = "../provenclaw-control-plane" }
 provenclaw-core = { path = "../provenclaw-core" }
 provenclaw-policy = { path = "../provenclaw-policy" }
 rand.workspace = true

--- a/crates/provenclaw-host/src/lib.rs
+++ b/crates/provenclaw-host/src/lib.rs
@@ -9,6 +9,9 @@ use chrono::{Duration, Utc};
 use ed25519_dalek::{Signer, SigningKey};
 use provenance::{ProvenactCliVerifier, Verifier};
 use provenclaw_audit::{AuditChainReport, AuditError, AuditRecord, AuditStore, ReceiptSummary};
+use provenclaw_control_plane::{
+    ControlPlane, ControlPlaneHealth, ControlPlaneProfile, LocalControlPlane,
+};
 use provenclaw_core::{
     CapabilitySpec, CoreError, EnforcementMode, FsRule, HttpRule, InvocationContext, MainConfig,
     ReceiptEnvelope, RiskLevel, SecurityPosture, ToolRegistration, ToolRegistry,
@@ -181,8 +184,15 @@ pub struct ProvenanceRunSummary {
 pub struct DiagnosticsReport {
     pub security_posture: SecurityPosture,
     pub secret_provider: SecretProviderStatus,
+    pub control_plane: ControlPlaneStatus,
     pub enforcement_slo: EnforcementSloReport,
     pub recent_provenance: Vec<ProvenanceRunSummary>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ControlPlaneStatus {
+    pub profile: ControlPlaneProfile,
+    pub health: ControlPlaneHealth,
 }
 
 #[derive(Debug, Clone)]
@@ -682,11 +692,22 @@ impl Host {
         Ok(DiagnosticsReport {
             security_posture: self.get_security_posture()?,
             secret_provider: default_provider_status(),
+            control_plane: self.get_control_plane_status()?,
             enforcement_slo: self.evaluate_enforcement_slo(
                 config.coverage_slo_window_days,
                 config.coverage_slo_target,
             )?,
             recent_provenance: self.get_provenance_report(25)?,
+        })
+    }
+
+    pub fn get_control_plane_status(&self) -> Result<ControlPlaneStatus, HostError> {
+        self.init_layout()?;
+        let config = self.load_config()?;
+        let control_plane = LocalControlPlane::for_local_host(config.enforcement_mode.clone());
+        Ok(ControlPlaneStatus {
+            profile: control_plane.profile(),
+            health: control_plane.health(),
         })
     }
 
@@ -1179,6 +1200,7 @@ fn load_receipt_items(receipt_dir: &Path) -> Result<Vec<ReceiptListItem>, HostEr
 #[cfg(test)]
 mod tests {
     use super::*;
+    use provenclaw_control_plane::{ControlPlaneHealth, ControlPlaneMode, TransportKind};
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
 
@@ -1387,5 +1409,23 @@ exit 1
 
         let receipts = host.list_receipts().unwrap();
         assert_eq!(receipts.len(), 1);
+    }
+
+    #[test]
+    fn diagnostics_report_exposes_local_control_plane_boundary() {
+        let root = std::env::temp_dir().join(format!("provenclaw-host-test-{}", Uuid::new_v4()));
+        let host = Host::with_paths(HostPaths::from_base_dir(root));
+        host.init_layout().unwrap();
+
+        let report = host.diagnostics_report().unwrap();
+        assert_eq!(report.control_plane.health, ControlPlaneHealth::Ready);
+        assert_eq!(
+            report.control_plane.profile.mode,
+            ControlPlaneMode::LocalOnly
+        );
+        assert_eq!(
+            report.control_plane.profile.endpoint.transport,
+            TransportKind::InProcess
+        );
     }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -13,15 +13,28 @@ ProvenClaw is a local execution-governance runtime for verified tools, with ente
 5. Policy engine validates policy signature and capability ceilings.
 6. Policy engine computes allow/deny.
 7. Enforcement mode (`warn` or `enforce`) applies provenance failure behavior.
-8. Runtime executor enforces capability preflight and delegates execution to `provenact run` with strict limits (no insecure fallback path).
-9. Host signs receipt and appends hash-chained audit record.
-10. CLI/TUI exposes deep verification and diagnostics.
+8. Host resolves control-plane contract (currently local in-process) for authn/authz/transport boundaries.
+9. Runtime executor enforces capability preflight and delegates execution to `provenact run` with strict limits (no insecure fallback path).
+10. Host signs receipt and appends hash-chained audit record.
+11. CLI/TUI exposes deep verification and diagnostics.
+
+## Control-plane boundaries
+
+- Host runtime and control-plane communicate only through typed contracts from `provenclaw-control-plane`.
+- Default Phase 0.5 mode is local in-process control-plane (`mode=local_only`, `transport=in_process`).
+- Remote-capable transport contract exists but is not active by default:
+  - `unix_socket`
+  - `loopback_http`
+  - `mtls_https`
+- Authn hooks are explicit (`local_shared_token`, `oidc_bearer`, `mutual_tls`, `workload_identity`).
+- Authz hooks are explicit with role-based decision points for high-risk actions (`manage_trust`, `manage_policy`, `set_enforcement_mode`).
 
 ## Crate responsibilities
 
 - `provenclaw-core`: shared security models (`EnforcementMode`, `VerificationReport`, signed `ReceiptEnvelope`, config model).
 - `provenclaw-policy`: policy schema, signature checks, capability ceiling checks, decision engine.
 - `provenclaw-audit`: append-only audit records, sequence/hash chain, chain verification, receipt store.
+- `provenclaw-control-plane`: control-plane API contracts, transport/auth hooks, role-based authorization boundary.
 - `provenclaw-host`: provenance verifier integration, runtime execution, receipt signing, trust/enforcement APIs.
 - `provenclaw-cli`: TUI-first entrypoint and automation-friendly subcommands.
 - `provenclaw-tui`: full-screen operations cockpit with command palette and multi-view navigation.

--- a/docs/CONTROL_PLANE.md
+++ b/docs/CONTROL_PLANE.md
@@ -1,0 +1,82 @@
+# Control Plane Contract (Phase 1 Skeleton)
+
+## Purpose
+
+Define a stable boundary between the host runtime and a future control plane while keeping Phase 0.5 local execution intact.
+
+## Current mode
+
+- Mode: `local_only`
+- Transport: `in_process`
+- Authn hook: `local_shared_token` (contracted)
+- Authz hook: embedded RBAC contract (`embedded-rbac`)
+
+The host currently instantiates a local control-plane profile and surfaces it in diagnostics.
+
+## API contracts
+
+Implemented in `/Users/jove/code/provenclaw/crates/provenclaw-control-plane/src/lib.rs`.
+
+### Requests
+
+- `health`
+- `profile`
+- `authorize`
+
+### Responses
+
+- `health`
+- `profile`
+- `authorize`
+
+### Authorization model
+
+Actions are role-gated.
+
+- Operator/auditor/security-admin actions:
+  - `run_tool`
+  - `read_receipts`
+  - `verify_receipts`
+  - `tail_audit`
+  - `export_diagnostics`
+- Security-admin-only actions:
+  - `manage_policy`
+  - `manage_trust`
+  - `set_enforcement_mode`
+
+## Transport choices (contracted)
+
+- `in_process`: default local Phase 0.5 path.
+- `unix_socket`: local daemon boundary for host <-> control-plane separation.
+- `loopback_http`: localhost-only integration for local control-plane service.
+- `mtls_https`: remote-capable endpoint for future enterprise control plane.
+
+Transport validation rules are enforced in the contract crate.
+
+## Authn/Authz hook choices
+
+Authn schemes (contracted):
+
+- `local_shared_token`
+- `oidc_bearer`
+- `mutual_tls`
+- `workload_identity`
+
+Authz hook modes:
+
+- `local`
+- `external`
+- `disabled` (not recommended)
+
+## Trust boundaries
+
+1. Host runtime never bypasses the control-plane authorization contract for governance actions.
+2. Transport type defines boundary hardness:
+   - `in_process` < `unix_socket` < `loopback_http` < `mtls_https`.
+3. Endpoint validation prevents obvious unsafe configurations (non-loopback loopback transport, non-absolute socket paths, non-HTTPS for mTLS transport).
+
+## Non-goals in this phase
+
+- No remote control plane implementation yet.
+- No production OIDC or mTLS handshake implementation yet.
+- No distributed state or tenancy model in this crate.

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -11,6 +11,7 @@
 ## Trust boundaries
 
 - CLI/user input -> host runtime.
+- Host runtime -> control-plane contract boundary.
 - Host runtime -> verified bundle runtime.
 - Host runtime -> network egress proxy boundary.
 - Host runtime -> policy and audit storage.

--- a/scripts/spec_parity.sh
+++ b/scripts/spec_parity.sh
@@ -7,6 +7,7 @@ required_paths=(
   "configs/policy.default.json"
   "configs/provenclaw.example.toml"
   "docs/ARCHITECTURE.md"
+  "docs/CONTROL_PLANE.md"
   "docs/THREAT_MODEL.md"
   "docs/OPERATIONS.md"
   "docs/ENTERPRISE_README.md"
@@ -15,6 +16,7 @@ required_paths=(
   "crates/provenclaw-host/src/lib.rs"
   "crates/provenclaw-policy/src/lib.rs"
   "crates/provenclaw-audit/src/lib.rs"
+  "crates/provenclaw-control-plane/src/lib.rs"
   "crates/provenclaw-cli/src/main.rs"
   "crates/provenclaw-tui/src/lib.rs"
 )


### PR DESCRIPTION
## Summary
- add new `provenclaw-control-plane` crate with typed control-plane request/response contracts
- define transport choices (`in_process`, `unix_socket`, `loopback_http`, `mtls_https`) and endpoint validation rules
- define authn/authz hooks and role-based authorization contract for governance actions
- surface control-plane status in host diagnostics without changing Phase 0.5 local runtime behavior
- document trust boundaries and control-plane contract in architecture/threat model docs

## Validation
- `cargo +1.88.0 fmt --all`
- `cargo +1.88.0 clippy --workspace --all-targets -- -D warnings`
- `cargo +1.88.0 test --workspace`
- `cargo +1.88.0 deny check advisories bans sources`
- `cargo +1.88.0 audit -q`
- `./scripts/spec_parity.sh`

Closes #3
